### PR TITLE
Fixing warning on db_instance creation

### DIFF
--- a/db_instance.tf
+++ b/db_instance.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "default" {
   identifier                = "production"
   instance_class            = "db.t2.micro"
   maintenance_window        = "sun:08:00-sun:09:00"
-  name                      = "blog_production"
+  db_name                   = "blog_production"
   parameter_group_name      = "default.postgres12"
   password                  = data.aws_ssm_parameter.db_instance__password.value
   username                  = "postgres"


### PR DESCRIPTION
```
│ Warning: Argument is deprecated
│
│   with aws_db_instance.default,
│   on db_instance.tf line 12, in resource "aws_db_instance" "default":
│   12:   name                      = "blog_production"
│
│ Use db_name instead
```